### PR TITLE
Remove sharp corners when using dash to dock

### DIFF
--- a/gnome-shell.css
+++ b/gnome-shell.css
@@ -1483,7 +1483,7 @@ StScrollBar {
 
 /* Dash */
 #dash {
-  background-color: #1d1f27; }
+  background-color: transparent; }
 
 .dash-background {
   background-color: #2e313d;


### PR DESCRIPTION
This theme looks waaay better than the base dracula gnome shell theme on gnome 40, thanks!

The dash container has an unnecessary background color rule that creates sharp, dark gray corners when using dash to dock.

This just sets the container to transparent, making the dock corners nice and smooth.

After:

![image](https://user-images.githubusercontent.com/7091399/146501227-e122aece-2f74-41fa-ab60-54af04dfc1bb.png)
