### PR TITLE
improved events button color scheme

### DIFF
--- a/gnome-shell.css
+++ b/gnome-shell.css
@@ -543,6 +543,52 @@ StScrollBar {
     background-color: #1e2128;
     color: #fafaf9; }
 
+/* Events */
+.events-button {
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 6px;
+  margin: 4px;
+  color: #eeeeec;
+  background-color: #292c37;
+  border-color: #1a1c23;
+  box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.1);
+  text-shadow: 0 1px rgba(0, 0, 0, 0.2);
+  icon-shadow: 0 1px rgba(0, 0, 0, 0.2);
+  padding: 12px; }
+  .events-button:focus {
+    color: #eeeeec;
+    text-shadow: 0 1px rgba(0, 0, 0, 0.2);
+    icon-shadow: 0 1px rgba(0, 0, 0, 0.2);
+    box-shadow: inset 0 0 0 2px rgba(251, 184, 108, 0.6); }
+  .events-button:hover {
+    color: #eeeeec;
+    background-color: #2e313d;
+    border-color: #1a1c23;
+    box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.3);
+    text-shadow: 0 1px rgba(0, 0, 0, 0.2);
+    icon-shadow: 0 1px rgba(0, 0, 0, 0.2); }
+  .events-button:active {
+    color: #eeeeec;
+    background-color: #1c1e25;
+    border-color: #0b0b0e;
+    text-shadow: none;
+    icon-shadow: none;
+    box-shadow: none; }
+  .events-button .events-box {
+    spacing: 6px; }
+  .events-button .events-list {
+    spacing: 12px; }
+  .events-button .events-title {
+    color: gray;
+    font-weight: bold;
+    margin-bottom: 4px; }
+  .events-button .event-time {
+    color: #b3b3b3;
+    font-feature-settings: "tnum";
+    font-size: 10pt; }
+
+
 /* World clocks */
 .world-clocks-button {
   border-width: 1px;


### PR DESCRIPTION
I noticed that events-button had a little off color scheme because it didn't had any classes for that.
So I tried to improve it a little bit, adding the default Gnome classes and changed colours.